### PR TITLE
Feature/fix rendering of table headers

### DIFF
--- a/Classes/Service/ExtractorService.php
+++ b/Classes/Service/ExtractorService.php
@@ -129,7 +129,7 @@ class ExtractorService
             }
 
             $rowsToRepeatAtTop = $sheet->getPageSetup()->getRowsToRepeatAtTop();
-            $range = 'A1:' . $sheet->getHighestColumn() . ($rowsToRepeatAtTop[1] + 1);
+            $range = 'A1:' . $sheet->getHighestColumn() . $rowsToRepeatAtTop[1];
             return $this->rangeToCellArray($range, true);
         } catch (SpreadsheetException $e) {
             // sheet or range of cells couldn't be loaded

--- a/Resources/Private/Partials/Columns.html
+++ b/Resources/Private/Partials/Columns.html
@@ -2,8 +2,16 @@
 
 <f:section name="Main">
 	<f:for each="{data}" key="column" as="value" iteration="columnIterator">
-		<f:render partial="Cell" section="Main"
-				  arguments="{cell: value, row: row, column: column, rowIterator: rowIterator, columnIterator: columnIterator}"/>
+        <f:if condition="{isTableHead} == true">
+            <f:then>
+                <f:render partial="HeaderCell" section="Main"
+                          arguments="{cell: value, row: row, column: column, rowIterator: rowIterator, columnIterator: columnIterator}"/>
+            </f:then>
+            <f:else>
+                <f:render partial="Cell" section="Main"
+                          arguments="{cell: value, row: row, column: column, rowIterator: rowIterator, columnIterator: columnIterator}"/>
+            </f:else>
+        </f:if>
 	</f:for>
 </f:section>
 

--- a/Resources/Private/Partials/HeaderCell.html
+++ b/Resources/Private/Partials/HeaderCell.html
@@ -1,0 +1,28 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+
+<f:section name="Main">
+	<f:if condition="{cell.rowspan} > 1 && {cell.colspan} > 1">
+		<f:then>
+			<th class="{cell.class}" rowspan="{cell.rowspan}" colspan="{cell.colspan}">
+				<f:render partial="Cell/Content" section="Main" arguments="{cell: cell}"/>
+			</th>
+		</f:then>
+		<f:else if="{cell.rowspan} > 1">
+			<th class="{cell.class}" rowspan="{cell.rowspan}">
+				<f:render partial="Cell/Content" section="Main" arguments="{cell: cell}"/>
+			</th>
+		</f:else>
+		<f:else if="{cell.colspan} > 1">
+			<th class="{cell.class}" colspan="{cell.colspan}">
+				<f:render partial="Cell/Content" section="Main" arguments="{cell: cell}"/>
+			</th>
+		</f:else>
+		<f:else>
+			<th class="{cell.class}">
+				<f:render partial="Cell/Content" section="Main" arguments="{cell: cell}"/>
+			</th>
+		</f:else>
+	</f:if>
+</f:section>
+
+</html>

--- a/Resources/Private/Templates/Table.html
+++ b/Resources/Private/Templates/Table.html
@@ -9,19 +9,21 @@
 				<f:if condition="{spreadsheet.headData}">
 					<thead>
 					<f:for each="{spreadsheet.headData}" key="row" as="rowData" iteration="rowIterator">
-						<th>
+                        <f:variable name="isTableHead" value="true"/>
+						<tr>
 							<f:render partial="Columns" section="Main"
-									  arguments="{data: rowData, row: row, rowIterator: rowIterator}"/>
-						</th>
+									  arguments="{data: rowData, row: row, rowIterator: rowIterator, isTableHead: isTableHead}"/>
+						</tr>
 					</f:for>
 					</thead>
 				</f:if>
 				<f:if condition="{spreadsheet.bodyData}">
 					<tbody>
 					<f:for each="{spreadsheet.bodyData}" key="row" as="rowData" iteration="rowIterator">
+                        <f:variable name="isTableHead" value="false"/>
 						<tr>
 							<f:render partial="Columns" section="Main"
-									  arguments="{data: rowData, row: row, rowIterator: rowIterator}"/>
+									  arguments="{data: rowData, row: row, rowIterator: rowIterator, isTablhead: isTableHead}"/>
 						</tr>
 					</f:for>
 					</tbody>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no tests were executed

<!--
This PR introduces rendering of table header cells (th) if the uploaded spreadsheet has a repeating row configured.
Furthermore, the range of the table header rows is reduced from two to one. The previous rendering of td inside of th is fixed.
-->
